### PR TITLE
Add login flow and level-based game

### DIFF
--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -48,15 +48,30 @@ class GameScene extends Phaser.Scene {
   private index = 0
   private startTime = 0
   private score = 0
+  private isGameOver = false
   private beatDelay = 600
   private readonly levelConfig
   private noteSprites: Phaser.GameObjects.Arc[] = []
   private scoreText!: Phaser.GameObjects.Text
   private progressLine!: Phaser.GameObjects.Line
+  private gameOverText?: Phaser.GameObjects.Text
 
   constructor(levelConfig: { instruments: string[]; bpm: [number, number] }) {
     super('GameScene')
     this.levelConfig = levelConfig
+  }
+
+  init() {
+    this.pattern = []
+    this.index = 0
+    this.startTime = 0
+    this.score = 0
+    this.isGameOver = false
+    this.noteSprites = []
+    if (this.gameOverText) {
+      this.gameOverText.destroy()
+      this.gameOverText = undefined
+    }
   }
 
   create() {
@@ -122,8 +137,12 @@ class GameScene extends Phaser.Scene {
     this.scoreText.setText(`Score: ${this.score}`)
     this.playInstrument(key)
     this.index += 1
+    if (result.result === 'MISS') {
+      this.gameOver()
+      return
+    }
     if (this.index === this.pattern.length) {
-      this.add.text(10, 40, `Final Score: ${this.score}`, { color: '#ffffff' }).setDepth(1)
+      this.gameOver(true)
     }
   }
 
@@ -146,6 +165,26 @@ class GameScene extends Phaser.Scene {
       },
       loop: true,
     })
+  }
+
+  private gameOver(completed = false) {
+    if (this.isGameOver) {
+      return
+    }
+    this.isGameOver = true
+    this.tweens.killAll()
+    const width = this.cameras.main.centerX
+    const height = this.cameras.main.centerY
+    const text = completed ? 'Stage Clear!' : 'Game Over'
+    this.gameOverText = this.add
+      .text(width, height, `${text}\nScore: ${this.score}\nClick to Restart`, {
+        color: '#ffffff',
+        align: 'center',
+      })
+      .setOrigin(0.5)
+      .setDepth(1)
+    this.input.keyboard.removeAllListeners()
+    this.input.once('pointerdown', () => this.scene.restart())
   }
 
   private playInstrument(key: string) {

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -50,6 +50,9 @@ class GameScene extends Phaser.Scene {
   private score = 0
   private beatDelay = 600
   private readonly levelConfig
+  private noteSprites: Phaser.GameObjects.Arc[] = []
+  private scoreText!: Phaser.GameObjects.Text
+  private progressLine!: Phaser.GameObjects.Line
 
   constructor(levelConfig: { instruments: string[]; bpm: [number, number] }) {
     super('GameScene')
@@ -62,6 +65,7 @@ class GameScene extends Phaser.Scene {
     this.beatDelay = 60000 / bpm
     this.input.keyboard.on('keydown', (event: KeyboardEvent) => this.handleKey(event.key))
     this.generatePattern()
+    this.createNoteVisuals()
     this.playDemonstration()
   }
 
@@ -73,13 +77,36 @@ class GameScene extends Phaser.Scene {
     }
   }
 
+  private createNoteVisuals() {
+    const width = this.cameras.main.width
+    const startX = 100
+    const endX = width - 100
+    const step = (endX - startX) / this.pattern.length
+    const y = this.cameras.main.centerY
+    this.scoreText = this.add.text(10, 10, 'Score: 0', { color: '#ffffff' }).setDepth(1)
+    this.pattern.forEach((key, i) => {
+      const instrument = INSTRUMENTS[key]
+      const x = startX + i * step
+      const color = parseInt(instrument.color.replace('#', ''), 16)
+      const circle = this.add.circle(x, y, 20, color).setStrokeStyle(2, 0xffffff)
+      this.add
+        .text(x, y + 30, key, { color: '#ffffff' })
+        .setOrigin(0.5, 0.5)
+      this.noteSprites.push(circle)
+    })
+    this.progressLine = this.add.line(0, y - 40, startX, 0, startX, 80, 0xffffff).setOrigin(0, 0.5)
+  }
+
   private async playDemonstration() {
-    for (const key of this.pattern) {
-      this.playInstrument(key)
+    for (let i = 0; i < this.pattern.length; i += 1) {
+      const note = this.noteSprites[i]
+      this.playInstrument(this.pattern[i])
+      this.tweens.add({ targets: note, scale: 1.3, yoyo: true, duration: this.beatDelay / 2 })
       await this.wait(this.beatDelay)
     }
     this.index = 0
     this.startTime = this.time.now
+    this.startUserPlay()
   }
 
   private handleKey(key: string) {
@@ -92,12 +119,33 @@ class GameScene extends Phaser.Scene {
     if (result.score > 0) {
       this.score += result.score
     }
-    this.add.text(10, 10, `Score: ${this.score}`, { color: '#ffffff' }).setDepth(1)
+    this.scoreText.setText(`Score: ${this.score}`)
     this.playInstrument(key)
     this.index += 1
     if (this.index === this.pattern.length) {
       this.add.text(10, 40, `Final Score: ${this.score}`, { color: '#ffffff' }).setDepth(1)
     }
+  }
+
+  private startUserPlay() {
+    const width = this.cameras.main.width
+    const endX = width - 100
+    this.tweens.add({
+      targets: this.progressLine,
+      x: endX,
+      duration: this.pattern.length * this.beatDelay,
+      ease: 'Linear',
+    })
+    this.time.addEvent({
+      delay: this.beatDelay,
+      callback: () => {
+        if (this.index < this.noteSprites.length) {
+          const note = this.noteSprites[this.index]
+          this.tweens.add({ targets: note, scale: 1.3, yoyo: true, duration: this.beatDelay / 2 })
+        }
+      },
+      loop: true,
+    })
   }
 
   private playInstrument(key: string) {

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -15,6 +15,7 @@ const LEVEL_CONFIG = [
 ]
 
 const PROGRESS_OFFSET = 100
+const PREPARE_TIME = 600
 
 function getLevelConfig(level: number) {
   return LEVEL_CONFIG.find((c) => level <= c.max) ?? LEVEL_CONFIG[0]
@@ -62,7 +63,8 @@ class GameScene extends Phaser.Scene {
   private progressStartX = 100
   private gameOverText?: Phaser.GameObjects.Text
   private hitText?: Phaser.GameObjects.Text
-
+  private noteTimer?: Phaser.Time.TimerEvent
+  
   constructor(levelConfig: { instruments: string[]; bpm: [number, number] }) {
     super('GameScene')
     this.levelConfig = levelConfig
@@ -75,6 +77,10 @@ class GameScene extends Phaser.Scene {
     this.score = 0
     this.isGameOver = false
     this.noteSprites = []
+    if (this.noteTimer) {
+      this.noteTimer.remove()
+      this.noteTimer = undefined
+    }
     if (this.hitText) {
       this.hitText.destroy()
       this.hitText = undefined
@@ -134,7 +140,6 @@ class GameScene extends Phaser.Scene {
       await this.wait(this.beatDelay)
     }
     this.index = 0
-    this.startTime = this.time.now
     this.startUserPlay()
   }
 
@@ -168,18 +173,17 @@ class GameScene extends Phaser.Scene {
     this.tweens.add({
       targets: this.progressLine,
       x: endX,
-      duration: this.pattern.length * this.beatDelay + PROGRESS_OFFSET,
+      duration: this.pattern.length * this.beatDelay + PREPARE_TIME,
       ease: 'Linear',
     })
-    this.time.addEvent({
-      delay: this.beatDelay,
-      callback: () => {
-        if (this.index < this.noteSprites.length) {
-          const note = this.noteSprites[this.index]
-          this.tweens.add({ targets: note, scale: 1.3, yoyo: true, duration: this.beatDelay / 2 })
-        }
-      },
-      loop: true,
+    this.time.delayedCall(PREPARE_TIME, () => {
+      this.startTime = this.time.now
+      this.highlightNextNote()
+      this.noteTimer = this.time.addEvent({
+        delay: this.beatDelay,
+        callback: () => this.highlightNextNote(),
+        loop: true,
+      })
     })
   }
 
@@ -211,6 +215,10 @@ class GameScene extends Phaser.Scene {
     }
     this.isGameOver = true
     this.tweens.killAll()
+    if (this.noteTimer) {
+      this.noteTimer.remove()
+      this.noteTimer = undefined
+    }
     const width = this.cameras.main.centerX
     const height = this.cameras.main.centerY
     const text = completed ? 'Stage Clear!' : 'Game Over'
@@ -223,6 +231,13 @@ class GameScene extends Phaser.Scene {
       .setDepth(1)
     this.input.keyboard.removeAllListeners()
     this.input.once('pointerdown', () => this.scene.restart())
+  }
+
+  private highlightNextNote() {
+    if (this.index < this.noteSprites.length) {
+      const note = this.noteSprites[this.index]
+      this.tweens.add({ targets: note, scale: 1.3, yoyo: true, duration: this.beatDelay / 2 })
+    }
   }
 
   private playInstrument(key: string) {

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import Phaser from 'phaser'
+import { INSTRUMENTS } from '@/constants/instruments'
+
+const LEVEL_CONFIG = [
+  { max: 3, instruments: ['1'], bpm: [60, 80] },
+  { max: 6, instruments: ['1', '2'], bpm: [80, 100] },
+  { max: 9, instruments: ['1', '2', '3'], bpm: [100, 120] },
+  { max: 12, instruments: ['1', '2', '3', '4'], bpm: [120, 140] },
+  { max: 15, instruments: ['1', '2', '3', '4', '5'], bpm: [140, 160] },
+  { max: 18, instruments: ['1', '2', '3', '4', '5', '6'], bpm: [160, 180] },
+]
+
+function getLevelConfig(level: number) {
+  return LEVEL_CONFIG.find((c) => level <= c.max) ?? LEVEL_CONFIG[0]
+}
+
+/**
+ * Evaluate hit timing and correctness.
+ */
+function judgeHit(
+  expectedKey: string,
+  actualKey: string,
+  expectedTime: number,
+  actualTime: number,
+) {
+  const diff = Math.abs(expectedTime - actualTime)
+  if (expectedKey !== actualKey) {
+    return { result: 'MISS', score: 0 }
+  }
+  if (diff <= 50) {
+    return { result: 'PERFECT', score: 100 }
+  }
+  if (diff <= 100) {
+    return { result: 'GREAT', score: 80 }
+  }
+  if (diff <= 150) {
+    return { result: 'GOOD', score: 60 }
+  }
+  return { result: 'MISS', score: 0 }
+}
+
+class GameScene extends Phaser.Scene {
+  private pattern: string[] = []
+  private index = 0
+  private startTime = 0
+  private score = 0
+  private beatDelay = 600
+  private readonly levelConfig
+
+  constructor(levelConfig: { instruments: string[]; bpm: [number, number] }) {
+    super('GameScene')
+    this.levelConfig = levelConfig
+  }
+
+  create() {
+    this.cameras.main.setBackgroundColor('#000')
+    const bpm = Phaser.Math.Between(this.levelConfig.bpm[0], this.levelConfig.bpm[1])
+    this.beatDelay = 60000 / bpm
+    this.input.keyboard.on('keydown', (event: KeyboardEvent) => this.handleKey(event.key))
+    this.generatePattern()
+    this.playDemonstration()
+  }
+
+  private generatePattern() {
+    const keys = this.levelConfig.instruments
+    for (let i = 0; i < 8; i += 1) {
+      const randomKey = keys[Math.floor(Math.random() * keys.length)]
+      this.pattern.push(randomKey)
+    }
+  }
+
+  private async playDemonstration() {
+    for (const key of this.pattern) {
+      this.playInstrument(key)
+      await this.wait(this.beatDelay)
+    }
+    this.index = 0
+    this.startTime = this.time.now
+  }
+
+  private handleKey(key: string) {
+    if (!INSTRUMENTS[key]) {
+      return
+    }
+    const expectedKey = this.pattern[this.index]
+    const expectedTime = this.startTime + this.index * this.beatDelay
+    const result = judgeHit(expectedKey, key, expectedTime, this.time.now)
+    if (result.score > 0) {
+      this.score += result.score
+    }
+    this.add.text(10, 10, `Score: ${this.score}`, { color: '#ffffff' }).setDepth(1)
+    this.playInstrument(key)
+    this.index += 1
+    if (this.index === this.pattern.length) {
+      this.add.text(10, 40, `Final Score: ${this.score}`, { color: '#ffffff' }).setDepth(1)
+    }
+  }
+
+  private playInstrument(key: string) {
+    const instrument = INSTRUMENTS[key]
+    const context = this.sound.context
+    const oscillator = context.createOscillator()
+    const gain = context.createGain()
+    oscillator.type = 'sine'
+    oscillator.frequency.value = instrument.frequency
+    oscillator.connect(gain)
+    gain.connect(context.destination)
+    oscillator.start()
+    gain.gain.setValueAtTime(0.5, context.currentTime)
+    oscillator.stop(context.currentTime + 0.2)
+  }
+
+  private wait(ms: number) {
+    return new Promise<void>((resolve) => {
+      this.time.delayedCall(ms, () => resolve())
+    })
+  }
+}
+
+export default function GamePage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    const player = localStorage.getItem('rhythmEcho_player')
+    if (!player) {
+      router.push('/login')
+      return
+    }
+    const level = Number(searchParams.get('level') || '1')
+    const levelConfig = getLevelConfig(level)
+    const config: Phaser.Types.Core.GameConfig = {
+      type: Phaser.AUTO,
+      width: 800,
+      height: 600,
+      parent: 'game-container',
+      scene: new GameScene(levelConfig),
+      audio: { disableWebAudio: false },
+    }
+    const game = new Phaser.Game(config)
+    return () => game.destroy(true)
+  }, [router, searchParams])
+
+  return <div id="game-container" className="w-full h-screen" />
+}
+

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -14,6 +14,8 @@ const LEVEL_CONFIG = [
   { max: 18, instruments: ['1', '2', '3', '4', '5', '6'], bpm: [160, 180] },
 ]
 
+const PROGRESS_OFFSET = 100
+
 function getLevelConfig(level: number) {
   return LEVEL_CONFIG.find((c) => level <= c.max) ?? LEVEL_CONFIG[0]
 }
@@ -32,13 +34,16 @@ function judgeHit(
     return { result: 'MISS', score: 0 }
   }
   if (diff <= 50) {
-    return { result: 'PERFECT', score: 100 }
+    return { result: 'EXCELLENT', score: 100 }
   }
   if (diff <= 100) {
-    return { result: 'GREAT', score: 80 }
+    return { result: 'GREAT', score: 70 }
   }
   if (diff <= 150) {
-    return { result: 'GOOD', score: 60 }
+    return { result: 'GOOD', score: 40 }
+  }
+  if (diff <= 200) {
+    return { result: 'BAD', score: 20 }
   }
   return { result: 'MISS', score: 0 }
 }
@@ -54,7 +59,9 @@ class GameScene extends Phaser.Scene {
   private noteSprites: Phaser.GameObjects.Arc[] = []
   private scoreText!: Phaser.GameObjects.Text
   private progressLine!: Phaser.GameObjects.Line
+  private progressStartX = 100
   private gameOverText?: Phaser.GameObjects.Text
+  private hitText?: Phaser.GameObjects.Text
 
   constructor(levelConfig: { instruments: string[]; bpm: [number, number] }) {
     super('GameScene')
@@ -68,6 +75,10 @@ class GameScene extends Phaser.Scene {
     this.score = 0
     this.isGameOver = false
     this.noteSprites = []
+    if (this.hitText) {
+      this.hitText.destroy()
+      this.hitText = undefined
+    }
     if (this.gameOverText) {
       this.gameOverText.destroy()
       this.gameOverText = undefined
@@ -109,7 +120,10 @@ class GameScene extends Phaser.Scene {
         .setOrigin(0.5, 0.5)
       this.noteSprites.push(circle)
     })
-    this.progressLine = this.add.line(0, y - 40, startX, 0, startX, 80, 0xffffff).setOrigin(0, 0.5)
+    this.progressStartX = startX - PROGRESS_OFFSET
+    this.progressLine = this.add
+      .line(this.progressStartX, y - 40, 0, 0, 0, 80, 0xffffff)
+      .setOrigin(0, 0.5)
   }
 
   private async playDemonstration() {
@@ -131,6 +145,7 @@ class GameScene extends Phaser.Scene {
     const expectedKey = this.pattern[this.index]
     const expectedTime = this.startTime + this.index * this.beatDelay
     const result = judgeHit(expectedKey, key, expectedTime, this.time.now)
+    this.showHitResult(result.result)
     if (result.score > 0) {
       this.score += result.score
     }
@@ -149,10 +164,11 @@ class GameScene extends Phaser.Scene {
   private startUserPlay() {
     const width = this.cameras.main.width
     const endX = width - 100
+    this.progressLine.x = this.progressStartX
     this.tweens.add({
       targets: this.progressLine,
       x: endX,
-      duration: this.pattern.length * this.beatDelay,
+      duration: this.pattern.length * this.beatDelay + PROGRESS_OFFSET,
       ease: 'Linear',
     })
     this.time.addEvent({
@@ -164,6 +180,28 @@ class GameScene extends Phaser.Scene {
         }
       },
       loop: true,
+    })
+  }
+
+  private showHitResult(result: string) {
+    if (this.hitText) {
+      this.hitText.destroy()
+    }
+    const color = '#ffffff'
+    this.hitText = this.add
+      .text(this.cameras.main.centerX, this.cameras.main.centerY - 100, result, {
+        color,
+        fontSize: '32px',
+      })
+      .setOrigin(0.5)
+    this.tweens.add({
+      targets: this.hitText,
+      alpha: 0,
+      duration: 500,
+      onComplete: () => {
+        this.hitText?.destroy()
+        this.hitText = undefined
+      },
     })
   }
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [name, setName] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const isValid = /^[A-Za-z0-9가-힣]{2,12}$/.test(name)
+    if (!isValid) {
+      setError('2-12자 한글/영문/숫자만 입력하세요.')
+      return
+    }
+    const data = {
+      name,
+      playerKey: `rhythmEcho_player_${Date.now()}`,
+      createdAt: new Date().toISOString(),
+    }
+    localStorage.setItem('rhythmEcho_player', JSON.stringify(data))
+    router.push('/game')
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen gap-4">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <input
+          className="border p-2 rounded"
+          value={name}
+          placeholder="플레이어 이름"
+          onChange={(e) => setName(e.target.value)}
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button type="submit" className="bg-blue-500 text-white p-2 rounded">
+          시작하기
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,25 @@
-import Image from "next/image";
+'use client'
+
+import Link from 'next/link'
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 
 export default function Home() {
-  return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const router = useRouter()
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+  useEffect(() => {
+    const player = localStorage.getItem('rhythmEcho_player')
+    if (player) {
+      router.push('/game')
+    }
+  }, [router])
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen gap-4">
+      <h1 className="text-2xl font-bold">Rhythm Echo</h1>
+      <Link href="/login" className="bg-blue-500 text-white p-2 rounded">
+        게임 시작
+      </Link>
     </div>
-  );
+  )
 }

--- a/src/constants/instruments.ts
+++ b/src/constants/instruments.ts
@@ -1,0 +1,19 @@
+export interface Instrument {
+  name: string;
+  sound: string;
+  color: string;
+  frequency: number;
+}
+
+export const INSTRUMENTS: Record<string, Instrument> = {
+  '1': { name: '킥드럼', sound: 'kick.wav', color: '#FF4444', frequency: 150 },
+  '2': { name: '스네어드럼', sound: 'snare.wav', color: '#44FF44', frequency: 220 },
+  '3': { name: '베이스기타', sound: 'bass.wav', color: '#4444FF', frequency: 180 },
+  '4': { name: '일렉기타', sound: 'guitar.wav', color: '#FFFF44', frequency: 300 },
+  '5': { name: '피아노', sound: 'piano.wav', color: '#FF44FF', frequency: 260 },
+  '6': { name: '신디사이저', sound: 'synth.wav', color: '#44FFFF', frequency: 320 },
+  '7': { name: '바이올린', sound: 'violin.wav', color: '#FFA844', frequency: 340 },
+  '8': { name: '트럼펫', sound: 'trumpet.wav', color: '#A844FF', frequency: 360 },
+  '9': { name: '첼로', sound: 'cello.wav', color: '#44FFA8', frequency: 200 },
+  '0': { name: '심벌', sound: 'cymbal.wav', color: '#FFB444', frequency: 400 },
+};


### PR DESCRIPTION
## Summary
- implement login page storing player info in localStorage
- add instrument definitions for each key
- refactor game page to use level-based settings and redirect when not logged in
- add minimal home page linking to login

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686e90f56714832facd23c0b13823337